### PR TITLE
Fix AI Summary button: Always trigger analysis for new documents

### DIFF
--- a/lib/screens/medical_summary_screen.dart
+++ b/lib/screens/medical_summary_screen.dart
@@ -5,8 +5,13 @@ import '../services/gemini_service.dart';
 
 class MedicalSummaryScreen extends StatefulWidget {
   final String userId;
+  final bool autoTriggerAnalysis;
 
-  const MedicalSummaryScreen({super.key, required this.userId});
+  const MedicalSummaryScreen({
+    super.key, 
+    required this.userId,
+    this.autoTriggerAnalysis = false,
+  });
 
   @override
   State<MedicalSummaryScreen> createState() => _MedicalSummaryScreenState();
@@ -22,7 +27,11 @@ class _MedicalSummaryScreenState extends State<MedicalSummaryScreen> {
   void initState() {
     super.initState();
     _setupAuthListener();
-    _loadSummary();
+    if (widget.autoTriggerAnalysis) {
+      _autoTriggerAnalysis();
+    } else {
+      _loadSummary();
+    }
   }
 
   void _setupAuthListener() {
@@ -76,41 +85,45 @@ class _MedicalSummaryScreenState extends State<MedicalSummaryScreen> {
         return;
       }
 
-      // If debug passes, try to get existing analysis first
-      final analysisData = await _geminiService.getMedicalAnalysis();
+      // Check analysis status first
+      final statusData = await _geminiService.checkAnalysisStatus();
       
-      if (analysisData['hasAnalysis'] && analysisData['summary'] != null) {
-        // We have existing analysis, check if new documents are available
-        if (analysisData['newDocumentsAvailable']) {
-          // There are new documents - show the cached summary but indicate update is available
-          setState(() {
-            _summary = '${analysisData['summary']}\n\n' +
-                      '⚠️ New documents available for analysis (${analysisData['newDocumentsCount']} new). ' +
-                      'Tap refresh to update your summary.';
-            _isLoading = false;
-          });
-        } else {
-          // Analysis is up to date
-          setState(() {
-            _summary = analysisData['summary'];
-            _isLoading = false;
-          });
-        }
-      } else {
-        // No existing analysis, check if we have documents to analyze
-        final statusData = await _geminiService.checkAnalysisStatus();
-        
+      if (!statusData['hasAnalysis']) {
+        // No existing analysis
         if (statusData['needsAnalysis']) {
-          // We have documents but no analysis - offer to generate one
+          // We have documents but no analysis - show generate button
           setState(() {
-            _summary = 'You have ${statusData['totalDocuments']} medical document(s) ready for analysis.\n\n' +
-                      'Tap the refresh button to generate your AI-powered medical summary.';
+            _summary = '📄 You have ${statusData['totalDocuments']} medical document(s) ready for AI analysis.\n\n'
+                      '🤖 Click "Generate Analysis" below to create your comprehensive medical summary using AI-powered text extraction and analysis.\n\n'
+                      '⏱️ This may take a moment as we analyze the content of your medical images.';
             _isLoading = false;
           });
         } else {
           // No documents available
           setState(() {
-            _summary = 'No medical documents found. Please upload some medical records first to generate an AI summary.';
+            _summary = '📋 No medical documents found.\n\n'
+                      'Please upload some medical records (lab reports, prescriptions, discharge summaries, etc.) first to generate an AI-powered medical summary.\n\n'
+                      '💡 Tip: Upload clear images of your medical documents for best results.';
+            _isLoading = false;
+          });
+        }
+      } else {
+        // We have existing analysis - get it and check for updates
+        final analysisData = await _geminiService.getMedicalAnalysis();
+        
+        if (analysisData['newDocumentsAvailable']) {
+          // There are new documents - show the cached summary but indicate update is available
+          setState(() {
+            _summary = '${analysisData['summary']}\n\n'
+                      '🆕 NEW: ${analysisData['newDocumentsCount']} new document(s) available for analysis.\n\n'
+                      '👆 Click "Update Analysis" above to analyze the new documents and update your summary.';
+            _isLoading = false;
+          });
+        } else {
+          // Analysis is up to date
+          setState(() {
+            _summary = '${analysisData['summary']}\n\n'
+                      '✅ Your analysis is up to date (includes ${analysisData['analyzedDocuments']} document(s)).';
             _isLoading = false;
           });
         }
@@ -234,6 +247,69 @@ class _MedicalSummaryScreenState extends State<MedicalSummaryScreen> {
     }
   }
 
+  Future<void> _autoTriggerAnalysis() async {
+    setState(() => _isLoading = true);
+
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) {
+        setState(() {
+          _summary = 'Authentication error: User not logged in';
+          _isLoading = false;
+        });
+        return;
+      }
+
+      print('🚀 Auto-triggering analysis...');
+      
+      // Check status first
+      final statusData = await _geminiService.checkAnalysisStatus();
+      
+      if (statusData['needsAnalysis']) {
+        // Show analysis is starting
+        setState(() {
+          _summary = '🔄 Analyzing your medical documents...\n\n'
+                    'This may take a moment as we process ${statusData['totalDocuments']} document(s) using AI-powered analysis.\n\n'
+                    'Please wait...';
+        });
+        
+        // Trigger analysis
+        final result = await _geminiService.analyzeMedicalRecords();
+        
+        setState(() {
+          _summary = result['summary'];
+          _isLoading = false;
+        });
+
+        // Show success message
+        if (mounted) {
+          final message = result['analysisType'] == 'incremental_update' 
+            ? 'Analysis updated with ${result['newDocumentsAnalyzed']} new document(s)'
+            : result['analysisType'] == 'initial_analysis'
+              ? 'Analysis completed for ${result['documentsAnalyzed']} document(s)'
+              : 'Analysis completed';
+              
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(message),
+              backgroundColor: Colors.green,
+              duration: const Duration(seconds: 3),
+            ),
+          );
+        }
+      } else {
+        // No new documents - just load existing summary
+        _loadSummary();
+      }
+    } catch (e) {
+      print('❌ Error in _autoTriggerAnalysis: $e');
+      setState(() {
+        _summary = 'Error generating analysis: $e';
+        _isLoading = false;
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -241,9 +317,9 @@ class _MedicalSummaryScreenState extends State<MedicalSummaryScreen> {
         title: const Text('Medical Summary'),
         actions: [
           IconButton(
-            icon: const Icon(Icons.refresh),
+            icon: const Icon(Icons.auto_awesome),
             onPressed: _refreshAnalysis,
-            tooltip: 'Generate/Update summary',
+            tooltip: 'Generate/Update AI Analysis',
           ),
           PopupMenuButton<String>(
             onSelected: (value) {
@@ -256,11 +332,11 @@ class _MedicalSummaryScreenState extends State<MedicalSummaryScreen> {
             itemBuilder: (context) => [
               const PopupMenuItem(
                 value: 'reload',
-                child: Text('Reload Summary'),
+                child: Text('Reload Status'),
               ),
               const PopupMenuItem(
                 value: 'force_reanalysis',
-                child: Text('Force Complete Re-analysis'),
+                child: Text('Re-analyze All Documents'),
               ),
             ],
           ),
@@ -274,15 +350,40 @@ class _MedicalSummaryScreenState extends State<MedicalSummaryScreen> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   const Text(
-                    'Your Medical History Summary',
+                    'AI Medical Summary',
                     style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
                   ),
                   const SizedBox(height: 8),
                   const Text(
-                    'Generated by AI based on your medical records',
+                    'AI-powered analysis of your medical records using advanced OCR and text understanding',
                     style: TextStyle(fontSize: 14, color: Colors.grey),
                   ),
                   const Divider(height: 32),
+                  
+                  // Show Generate Analysis button if no analysis exists and documents are available
+                  if (_summary.contains('ready for AI analysis') || _summary.contains('new document(s) available')) ...[
+                    Center(
+                      child: Column(
+                        children: [
+                          ElevatedButton.icon(
+                            onPressed: _refreshAnalysis,
+                            icon: const Icon(Icons.auto_awesome),
+                            label: Text(_summary.contains('new document(s) available') 
+                              ? 'Update Analysis' 
+                              : 'Generate AI Analysis'),
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.teal,
+                              foregroundColor: Colors.white,
+                              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                              textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                            ),
+                          ),
+                          const SizedBox(height: 24),
+                        ],
+                      ),
+                    ),
+                  ],
+                  
                   Text(_summary),
                 ],
               ),


### PR DESCRIPTION
- Modified patient dashboard to check for new documents before navigating to summary
- Added autoTriggerAnalysis parameter to MedicalSummaryScreen
- Updated medical records screen to auto-trigger analysis when viewing summary
- Now AI Summary button truly triggers fresh analysis for new documents
- Removed stale cache issues when user requests analysis